### PR TITLE
Fix single-file force-upload pulling in stale directory state

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ uv run dbx-sync ./local-project /Workspace/Users/me/project
 
 ## Usage
 
+The command takes two positional arguments: the **first** is always the **local** path (file or directory) and the **second** is always the **remote** Databricks workspace path (file or folder):
+
+```bash
+dbx-sync <local-path> <remote-workspace-path>
+```
+
 Sync a single workspace folder with a single local folder (one-time):
 
 ```bash

--- a/src/dbx_sync/__init__.py
+++ b/src/dbx_sync/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/src/dbx_sync/sync.py
+++ b/src/dbx_sync/sync.py
@@ -578,7 +578,12 @@ def run_sync_pass(
     removed = 0
     skipped = 0
 
-    candidate_paths = set(remote_candidates) | set(files_state)
+    if remote_file is not None:
+        # Single-file mode: only consider the target path, ignoring stale state
+        # entries left over from prior directory syncs sharing the same config.
+        candidate_paths = {remote_file}
+    else:
+        candidate_paths = set(remote_candidates) | set(files_state)
 
     for remote_path in sorted(candidate_paths):
         action, file_state, remote_item, local_path = _resolve_file_action(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -885,6 +885,51 @@ def test_run_sync_pass_single_local_file_uploads_to_remote_directory(
     assert mock_get_status.call_count >= 1
 
 
+@patch("dbx_sync.sync.upload_workspace_item")
+@patch("dbx_sync.sync.get_status", return_value={"object_type": "FILE", "modified_at": 9000})
+@patch("dbx_sync.sync.list_workspace")
+def test_run_sync_pass_single_file_force_upload_ignores_stale_directory_state(
+    mock_list_workspace: MagicMock,
+    mock_get_status: MagicMock,
+    mock_upload: MagicMock,
+    tmp_path: Path,
+) -> None:
+    target_file = tmp_path / "data.csv"
+    target_file.write_text("a,b\n1,2", encoding="utf-8")
+    other_file = tmp_path / "other.py"
+    other_file.write_text("# other", encoding="utf-8")
+    other_mtime_ms = int(other_file.stat().st_mtime * 1000)
+    config_path = tmp_path / ".databricks" / "dbx-sync" / "config.json"
+    config = {
+        "local_dir": str(tmp_path),
+        "local_file_path": str(target_file),
+        "remote_path": "/workspace",
+        "remote_file_path": "/workspace/data.csv",
+        "profile": "DEFAULT",
+        # Stale state left over from a prior directory sync sharing this config.
+        "files": {
+            "/workspace/other": {
+                **sync._default_file_state(),
+                "local_path": str(other_file),
+                "object_type": "NOTEBOOK",
+                "language": "PYTHON",
+                "last_synced_remote_modified_ms": other_mtime_ms,
+                "last_synced_local_modified_ms": other_mtime_ms,
+            }
+        },
+    }
+
+    result = sync.run_sync_pass(
+        config, config_path, dry_run=False, force_type=sync.ForceType.UPLOAD
+    )
+
+    assert result["uploaded"] == 1
+    mock_upload.assert_called_once()
+    uploaded_item = mock_upload.call_args.args[0]
+    assert uploaded_item.path == "/workspace/data.csv"
+    mock_list_workspace.assert_not_called()
+
+
 @patch("dbx_sync.sync.download_workspace_item")
 @patch("dbx_sync.sync.get_status")
 @patch("dbx_sync.sync.list_workspace")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -978,6 +978,57 @@ def test_run_sync_pass_single_file_force_download_ignores_stale_directory_state(
 @patch("dbx_sync.sync.download_workspace_item")
 @patch("dbx_sync.sync.get_status")
 @patch("dbx_sync.sync.list_workspace")
+def test_run_sync_pass_single_remote_file_force_ignores_stale_directory_state(
+    mock_list_workspace: MagicMock,
+    mock_get_status: MagicMock,
+    mock_download: MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_get_status.return_value = {
+        "object_type": "NOTEBOOK",
+        "language": "PYTHON",
+        "modified_at": 5000,
+    }
+    mock_download.side_effect = lambda item, path, profile: path.write_text(
+        "# downloaded", encoding="utf-8"
+    )
+    other_file = tmp_path / "other.py"
+    other_file.write_text("# other", encoding="utf-8")
+    other_mtime_ms = int(other_file.stat().st_mtime * 1000)
+    config_path = tmp_path / ".databricks" / "dbx-sync" / "config.json"
+    # Local path is a directory while the remote resolves to a single file.
+    config = {
+        "local_dir": str(tmp_path),
+        "remote_path": "/workspace",
+        "remote_file_path": "/workspace/notebook",
+        "profile": "DEFAULT",
+        # Stale state left over from a prior directory sync sharing this config.
+        "files": {
+            "/workspace/other": {
+                **sync._default_file_state(),
+                "local_path": str(other_file),
+                "object_type": "NOTEBOOK",
+                "language": "PYTHON",
+                "last_synced_remote_modified_ms": other_mtime_ms,
+                "last_synced_local_modified_ms": other_mtime_ms,
+            }
+        },
+    }
+
+    result = sync.run_sync_pass(
+        config, config_path, dry_run=False, force_type=sync.ForceType.DOWNLOAD
+    )
+
+    assert result["downloaded"] == 1
+    mock_download.assert_called_once()
+    downloaded_item = mock_download.call_args.args[0]
+    assert downloaded_item.path == "/workspace/notebook"
+    mock_list_workspace.assert_not_called()
+
+
+@patch("dbx_sync.sync.download_workspace_item")
+@patch("dbx_sync.sync.get_status")
+@patch("dbx_sync.sync.list_workspace")
 def test_run_sync_pass_single_remote_file_downloads_to_local_directory(
     mock_list_workspace: MagicMock,
     mock_get_status: MagicMock,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -931,6 +931,51 @@ def test_run_sync_pass_single_file_force_upload_ignores_stale_directory_state(
 
 
 @patch("dbx_sync.sync.download_workspace_item")
+@patch("dbx_sync.sync.get_status", return_value={"object_type": "FILE", "modified_at": 9000})
+@patch("dbx_sync.sync.list_workspace")
+def test_run_sync_pass_single_file_force_download_ignores_stale_directory_state(
+    mock_list_workspace: MagicMock,
+    mock_get_status: MagicMock,
+    mock_download: MagicMock,
+    tmp_path: Path,
+) -> None:
+    target_file = tmp_path / "data.csv"
+    target_file.write_text("a,b\n1,2", encoding="utf-8")
+    other_file = tmp_path / "other.py"
+    other_file.write_text("# other", encoding="utf-8")
+    other_mtime_ms = int(other_file.stat().st_mtime * 1000)
+    config_path = tmp_path / ".databricks" / "dbx-sync" / "config.json"
+    config = {
+        "local_dir": str(tmp_path),
+        "local_file_path": str(target_file),
+        "remote_path": "/workspace",
+        "remote_file_path": "/workspace/data.csv",
+        "profile": "DEFAULT",
+        # Stale state left over from a prior directory sync sharing this config.
+        "files": {
+            "/workspace/other": {
+                **sync._default_file_state(),
+                "local_path": str(other_file),
+                "object_type": "NOTEBOOK",
+                "language": "PYTHON",
+                "last_synced_remote_modified_ms": other_mtime_ms,
+                "last_synced_local_modified_ms": other_mtime_ms,
+            }
+        },
+    }
+
+    result = sync.run_sync_pass(
+        config, config_path, dry_run=False, force_type=sync.ForceType.DOWNLOAD
+    )
+
+    assert result["downloaded"] == 1
+    mock_download.assert_called_once()
+    downloaded_item = mock_download.call_args.args[0]
+    assert downloaded_item.path == "/workspace/data.csv"
+    mock_list_workspace.assert_not_called()
+
+
+@patch("dbx_sync.sync.download_workspace_item")
 @patch("dbx_sync.sync.get_status")
 @patch("dbx_sync.sync.list_workspace")
 def test_run_sync_pass_single_remote_file_downloads_to_local_directory(


### PR DESCRIPTION
## Problem

When specifying a single local file and a remote directory with `--force-upload --dry-run`, all local files were shown as to-be-uploaded instead of just the targeted file.

## Cause

`run_sync_pass` built its candidate set as `set(remote_candidates) | set(files_state)`. The persisted `files_state` (in `.databricks/dbx-sync/config.json`) is shared per local directory and accumulates entries from prior directory syncs. In single-file mode those stale entries were pulled in, so `--force-upload` marked every previously tracked local file for upload.

## Fix

In single-file mode (when `remote_file_path` is set), restrict the candidate set to just the target path, ignoring stale state entries.

## Changes

- Limit candidate paths to the single target in single-file mode.
- Add regression test `test_run_sync_pass_single_file_force_upload_ignores_stale_directory_state`.
- Bump version to 0.4.1.

## Validation

`ruff format`, `ruff check`, `ty check`, and `pytest` (96 passed) all pass.